### PR TITLE
Update classes_de_TEIA.ipynb

### DIFF
--- a/classes_de_TEIA.ipynb
+++ b/classes_de_TEIA.ipynb
@@ -584,7 +584,7 @@
     }
    ],
    "source": [
-    "metadata_path['Class'].value_counts()"
+    "print(metadata_path['Class'].value_counts().to_frame())"
    ]
   }
  ],


### PR DESCRIPTION
Remoção da última linha da saída do código `metadata_path['Class'].value_counts()` onde havia _Name: Class, dtype: int64_

.